### PR TITLE
Suggest using localhost on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ When starting the server, you can ignore the message `nnUNet_raw is not defined 
 
 1. [Download and install latest version of **3D Slicer**](https://slicer.readthedocs.io/en/latest/user_guide/getting_started.html#installing-3d-slicer)
 2. [Install **NNInteractive** extension](https://slicer.readthedocs.io/en/latest/user_guide/extensions_manager.html#install-extensions)
-3. Go to the `nnInteractive` module in Slicer and in the `Configuration` tab type in the URL of the server you set up in the [server side](#server-side) installation procedure. This should look something like `http://remote_host_name:1527` or, if you run the server locally, `http://localhost:1527`.
+3. Go to the `nnInteractive` module in Slicer and in the `Configuration` tab type in the URL of the server you set up in the [server side](#server-side) installation procedure. This should look something like `http://remote_host_name:1527` or, if you run the server locally, `http://localhost:1527`.  On Windows you may need to use `localhost` even if the server suggests using `0.0.0.0`.
 
 ## Usage
 


### PR DESCRIPTION
For my test 0.0.0.0 did not work on Windows, but localhost did.  I used the pixi method to set up the server.

It looks like 0.0.0.0 is suggested automatically by the server.  It could make sense to override that or add a message suggesting the localhost version of the URL for configuration.